### PR TITLE
Fixed json_record_limit being interpreted as 0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,7 @@ Summary:
 Thanks:
 
 * Robin Thomas from Squarespace
-* Jose Juan Montes (@jjmontsl)
+* Jose Juan Montes (@jjmontesl)
 
 New Features
 ============

--- a/cubes/server/controllers.py
+++ b/cubes/server/controllers.py
@@ -51,7 +51,7 @@ class ApplicationController(object):
         self.model = self.workspace.localized_model(self.locale)
 
         if config.has_option("server","json_record_limit"):
-            self.json_record_limit = config.get("server","json_record_limit")
+            self.json_record_limit = int(config.get("server","json_record_limit"))
         else:
             self.json_record_limit = 1000
 


### PR DESCRIPTION
Fixes json_record_limit being interpreted as 0, by parsing the configuration value as an integer.
