### PR TITLE
Helloworld fix

### DIFF
--- a/examples/hello_world/slicer.ini
+++ b/examples/hello_world/slicer.ini
@@ -4,6 +4,7 @@ port: 5000
 reload: yes
 log_level: info
 prettyprint: yes
+backend: sql
 
 [workspace]
 type: sql


### PR DESCRIPTION
By default, the hello_world example fails to run:

```
$PROJECT_ROOT/cubes/examples/hello_world> slicer serve slicer.ini

2013-12-10 15:03:50,356 WARNING no backend specified, using 'sql'
2013-12-10 15:03:50,357 WARNING no section [workspace] found in slicer config, using empty options
2013-12-10 15:03:50,357 INFO using backend 'sql'
ERROR: No URL or engine specified in options, provide at least one
```

These issues are related to the default values in the slicer.ini. Adding a backend value to the [server] block removes a distracting debug message and changing the "datastore" config block to be named "workspace" resolves the fatal error when trying to run the demo dev server.
