### PR TITLE
Pre-aggregation pipeline support

### DIFF
--- a/cubes/backends/mongo2/browser.py
+++ b/cubes/backends/mongo2/browser.py
@@ -403,7 +403,7 @@ class Mongo2Browser(AggregationBrowser):
 
             group_obj[ escape_level(agg.ref()) ] = group
 
-        pipeline = []
+        pipeline = self.cube.mappings.get("__pipeline__", [])
         pipeline.append({ "$match": query_obj })
         if fields_obj:
             pipeline.append({ "$project": fields_obj })

--- a/cubes/backends/mongo2/functions.py
+++ b/cubes/backends/mongo2/functions.py
@@ -33,6 +33,14 @@ _aggregate_functions = {
         'group_by': (lambda field: { '$sum': "$%s" % field }),
         'aggregate_fn': sum,
     },
+    'first': {
+        'group_by': (lambda field: { '$first': "$%s" % field }),
+        'aggregate_fn': None,                                       # Is this used?
+    },
+    'last': {
+        'group_by': (lambda field: { '$last': "$%s" % field }),
+        'aggregate_fn': None,                                       # Is this used?
+    },
     'custom': {
         'group_by' : (lambda field: { '$sum': 1 }),
         'aggregate_fn': len


### PR DESCRIPTION
Hi, I recently started experimenting with Cubes, using the Mongo2 backend. I have a need to run a few pipeline stages ahead of the cubes-computed pipeline. This patch provides a way to inject pipeline stages. It also provides support for '$first' and '$last' aggregation operators.
