### PR TITLE
Fix double-invert in sql SetCut implementation

### DIFF
--- a/cubes/backends/sql/query.py
+++ b/cubes/backends/sql/query.py
@@ -1410,7 +1410,7 @@ class QueryBuilder(object):
                 for path in cut.paths:
                     condition = self.condition_for_point(dim, path,
                                                          cut.hierarchy,
-                                                         cut.invert)
+                                                         invert=False)
                     set_conds.append(condition)
 
                 condition = sql.expression.or_(*set_conds)


### PR DESCRIPTION
When invert=True is passed to the sql implementation of SetCut the conditions are inverted twice resulting in  a wrong expression. This commit makes sure only the combined condition is inverted and not the individual ones.
