### PR TITLE
UTF-8 parameters in URL query

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,11 +1,6 @@
 Cubes - Online Analytical Processing Framework for Python
 =========================================================
 
-Update
-------
-
-Support using Chinese as cut parameters in URL.
-
 About
 -----
 

--- a/cubes/browser.py
+++ b/cubes/browser.py
@@ -1267,7 +1267,7 @@ def _path_part_unescape(path_part):
 
 
 def string_from_cuts(cuts):
-    """Returns a string represeting `cuts`(in unicode). String(support Chinese) can be used in URLs"""
+    """Returns a string represeting `cuts`. String can be used in URLs"""
     strings = [unicode(cut) for cut in cuts]
     string = CUT_STRING_SEPARATOR_CHAR.join(strings)
     return string

--- a/cubes/common.py
+++ b/cubes/common.py
@@ -233,14 +233,9 @@ def coalesce_options(options, types):
     return out
 
 def to_unicode_string(s):
-    """Encode parameters from URL to unicode. First check if `s`
-    is unicode. If it is, then convert it to UTF-8. Otherwise make it a str"""
-
     if isinstance(s, unicode):
-        s = s.encode('utf-8')
-    else:
-        s = str(s)
-
+        return s
+    s = str(s)
     for enc in ('utf8', 'latin-1'):
         try:
             return unicode(s, enc)


### PR DESCRIPTION
WIth MongoDB as backend, which supports UTF-8 encoding natively, we hope to directly pass in non-ascii characters (such as Chinese, in Kersey Long's situation #198 ) in the URL query, for specifying cuts.
