### PR TITLE
Environment variables

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,6 +53,16 @@ Source
 
 Github source repository: https://github.com/Stiivi/cubes
 
+
+Run tests like so.
+
+    python setup.py test
+
+Run just one test like so.
+
+    python -m unittest tests.TEST_MODULE.TEST_CASE.TEST_FUNCTION
+
+
 Requirements
 ------------
 

--- a/cubes/configuration.py
+++ b/cubes/configuration.py
@@ -1,20 +1,31 @@
 import os
 import configparser
 
+def _interpolate(self, parser, section, option, value, *defaults):
+    try:
+        return value % os.environ
+    except KeyError:
+        raise EnvironmentVariableMissingError\
+              (option, section, value)
+
+class EnvironmentVariableMissingError(configparser.InterpolationError):
+    """A string substitution required a setting which was not available."""
+
+    def __init__(self, option, section, rawval):
+        msg = ("Bad value substitution:\n"
+               "\tsection: [%s]\n"
+               "\toption : %s\n"
+               "\trawval : %s\n"
+               % (section, option, rawval))
+        configparser.InterpolationError.__init__(self, option, section, msg)
+
 class EnvironmentInterpolation(configparser.Interpolation):
     """Interpolate from the environment"""
 
-    def before_get(self, parser, section, option, value, defaults):
-        return value % os.environ
-
-    def before_set(self, parser, section, option, value):
-        return value % os.environ
-
-    def before_read(self, parser, section, option, value):
-        return value % os.environ
-
-    def before_write(self, parser, section, option, value):
-        return value % os.environ
+    before_get = _interpolate
+    before_set = _interpolate
+   #before_read = _interpolate
+   #before_write = _interpolate
 
 
 class EnvironmentConfigParser(configparser.ConfigParser):

--- a/cubes/configuration.py
+++ b/cubes/configuration.py
@@ -1,0 +1,21 @@
+import os
+import configparser
+
+class EnvironmentInterpolation(configparser.Interpolation):
+    """Interpolate from the environment"""
+
+    def before_get(self, parser, section, option, value, defaults):
+        return value % os.environ
+
+    def before_set(self, parser, section, option, value):
+        return value % os.environ
+
+    def before_read(self, parser, section, option, value):
+        return value % os.environ
+
+    def before_write(self, parser, section, option, value):
+        return value % os.environ
+
+
+class EnvironmentConfigParser(configparser.ConfigParser):
+    _DEFAULT_INTERPOLATION = EnvironmentInterpolation()

--- a/fixtures/procurements.ini
+++ b/fixtures/procurements.ini
@@ -1,0 +1,32 @@
+# Slicer OLAP server configuration
+#
+# replace VVO_ROOT with absolute path to VVO files
+# 
+
+[workspace]
+log_level: debug
+
+[server]
+# Set writeable path for logging slicer info
+prettyprint: true
+allow_cors_origin: *
+reload: true
+
+[store]
+type: sql
+url: %(DATABASE_URL)s
+fact_prefix: ft_
+dimension_prefix: dm_
+debug: true
+
+[models]
+main: procurements.cubesmodel
+
+[translation-sk]
+main: vvo_model-sk.json
+
+[translations]
+main: vvo_model-sk.json
+
+[translation-main]
+sk: vvo_model-sk.json

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,5 +1,5 @@
 import os
-from cubes.configuration import EnvironmentConfigParser
+from cubes.configuration import EnvironmentConfigParser, EnvironmentVariableMissingError
 
 from .common import CubesTestCaseBase
 
@@ -10,18 +10,16 @@ class ConfigurationTestCase(CubesTestCaseBase):
         CubesTestCaseBase.setUp(self)
         self.c = EnvironmentConfigParser()
         self.url = 'sqlite:///procurements.sqlite'
+        self.c.read(fn)
 
     def test_interpolation(self):
         os.environ['DATABASE_URL'] = self.url
-        self.c.read(fn)
         self.assertEqual(self.c['store']['url'], self.url)
         del(os.environ['DATABASE_URL'])
 
     def test_no_interpolation(self):
-        self.c.read(fn)
         self.assertEqual(self.c['store']['type'], 'sql')
 
     def test_interpolation_error(self):
-        # self.assertRaises
-        c['store']['url']
-        assert False
+        with self.assertRaises(EnvironmentVariableMissingError):
+            self.c['store']['url']

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,26 @@
+import os
+from cubes.configuration import EnvironmentConfigParser
+
+from .common import CubesTestCaseBase
+
+
+class ConfigurationTestCase(WorkspaceTestCaseBase):
+    def setUp(self):
+        WorkspaceTestCaseBase.setup(self)
+        fn = os.path.join('fixtures', 'procurements.ini')
+        self.c = EnvironmentConfigParser()
+        self.c.read(fn)
+        self.url = 'sqlite:///procurements.sqlite'
+
+    def test_interpolation(self):
+        os.environ['DATABASE_URL'] = self.url
+        self.assertEqual(c['store']['url'], self.url)
+        del(os.environ['DATABASE_URL'])
+
+    def test_no_interpolation(self):
+        self.assertEqual(c['store']['type'], 'sql')
+
+    def test_interpolation_error(self):
+        # self.assertRaises
+        c['store']['url']
+        assert False

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,21 +4,22 @@ from cubes.configuration import EnvironmentConfigParser
 from .common import CubesTestCaseBase
 
 
+fn = os.path.join('fixtures', 'procurements.ini')
 class ConfigurationTestCase(CubesTestCaseBase):
     def setUp(self):
         CubesTestCaseBase.setUp(self)
-        fn = os.path.join('fixtures', 'procurements.ini')
         self.c = EnvironmentConfigParser()
-        self.c.read(fn)
         self.url = 'sqlite:///procurements.sqlite'
 
     def test_interpolation(self):
         os.environ['DATABASE_URL'] = self.url
-        self.assertEqual(c['store']['url'], self.url)
+        self.c.read(fn)
+        self.assertEqual(self.c['store']['url'], self.url)
         del(os.environ['DATABASE_URL'])
 
     def test_no_interpolation(self):
-        self.assertEqual(c['store']['type'], 'sql')
+        self.c.read(fn)
+        self.assertEqual(self.c['store']['type'], 'sql')
 
     def test_interpolation_error(self):
         # self.assertRaises

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,9 +4,9 @@ from cubes.configuration import EnvironmentConfigParser
 from .common import CubesTestCaseBase
 
 
-class ConfigurationTestCase(WorkspaceTestCaseBase):
+class ConfigurationTestCase(CubesTestCaseBase):
     def setUp(self):
-        WorkspaceTestCaseBase.setup(self)
+        CubesTestCaseBase.setUp(self)
         fn = os.path.join('fixtures', 'procurements.ini')
         self.c = EnvironmentConfigParser()
         self.c.read(fn)


### PR DESCRIPTION
Swap `ConfigParser` imports for `cubes.configuration.EnvironmentConfigParser`, and
[this](https://github.com/Stiivi/cubes/issues/209) will be ready, except that the syntax will be `%(DATABASE_URL)s`.

I didn't do the actual swap because the tests were broken in master.