### PR TITLE
added 'partition' attribute to store

### DIFF
--- a/cubes/backends/sql/browser.py
+++ b/cubes/backends/sql/browser.py
@@ -76,6 +76,7 @@ class SnowflakeBrowser(AggregationBrowser):
         * locale is implemented as denormalized: one column for each language
 
         """
+
         super(SnowflakeBrowser, self).__init__(cube, store)
 
         if not cube:
@@ -160,6 +161,7 @@ class SnowflakeBrowser(AggregationBrowser):
         attributes = self.cube.get_attributes(fields)
 
         builder = QueryBuilder(self)
+
         builder.denormalized_statement(attributes=attributes,
                                        include_fact_key=True)
 

--- a/cubes/backends/sql/mapper.py
+++ b/cubes/backends/sql/mapper.py
@@ -170,6 +170,7 @@ class SnowflakeMapper(Mapper):
                             (fact_prefix, self.cube.basename, fact_suffix)
         self.schema = schema
 
+        self.partition = options.get('partition')
         self._collect_joins(joins or cube.joins)
 
     def _collect_joins(self, joins):


### PR DESCRIPTION

Due to the size of our datasets we make heavy use of MySQL partitions. 

MySQL partitions require that the partition key be present in every query.

This patch lets you specify

```
[store]
partition: some_column_name
```

If it's present it adds an extra equi join condition from the fact table to each dimension that's equivalent to this:

```sql
FROM 
fact_table
INNER JOIN fact_table ON (
   fact_table.dimension_id = dimension_table.id  
  AND fact_table.partition = dimension.partition
)
```

Which is enough to take advantage of the partitions. 

I consider this to be more of a demonstration/proof of concept than anything else as more flexible option would be to extend the mapper to allow joining on multiple columns.
