### PR TITLE
Optional workspace

### DIFF
--- a/cubes/server/blueprint.py
+++ b/cubes/server/blueprint.py
@@ -75,6 +75,7 @@ def _store_option(config, option, default, type_=None, allowed=None,
 
     setattr(current_app.slicer, option, value)
 
+
 @slicer.record_once
 def initialize_slicer(state):
     """Create the workspace and configure the application context from the
@@ -89,7 +90,8 @@ def initialize_slicer(state):
         params = CustomDict()
         current_app.slicer = params
         current_app.slicer.config = config
-        current_app.cubes_workspace = Workspace(config)
+        if not hasattr(current_app, 'cubes_workspace'):
+            current_app.cubes_workspace = Workspace(config)
 
         # Configure the application
         _store_option(config, "prettyprint", False, "bool")


### PR DESCRIPTION
As discussed before, this allows users to supply an existing workspace to the slicer. To be honest, I'd prefer an even cleaner solution where the slicer is supplied a workspace by default, rather than configuring itself. 