### PR TITLE
travis, sqlite3 version, 2.7 compat fixes for tests and ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
     - 2.7
     - 3.3
     - 3.4
-install: pip install -r requirements-optional.txt --use-mirrors
+install: 
+    - pip install -r requirements.txt --use-mirrors
+    - pip install -r requirements-optional.txt --use-mirrors
 script: python setup.py develop && python setup.py test
 

--- a/tests/sql/common.py
+++ b/tests/sql/common.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import unittest
 import sqlalchemy as sa
 from datetime import datetime
+from cubes import compat
 
 # TODO: use the data.py version
 def create_table(engine, md, desc):
@@ -55,7 +56,8 @@ def create_table(engine, md, desc):
             record[key] = value
         buffer.append(record)
 
-    engine.execute(table.insert(buffer))
+    for row in buffer:
+        engine.execute(table.insert(row))
 
     return table
 
@@ -76,3 +78,6 @@ class SQLTestCase(unittest.TestCase):
     def table(self, name):
         """Return fully reflected table `name`"""
         return self.metadata.table(name, autoload=True)
+
+    if not compat.py3k:
+        assertCountEqual = unittest.TestCase.assertItemsEqual

--- a/tests/sql/dw/demo.py
+++ b/tests/sql/dw/demo.py
@@ -235,7 +235,8 @@ class TinyDemoDataWarehouse(object):
             buffer.append(record)
 
         if buffer:
-            self.engine.execute(table.insert(buffer))
+            for row in buffer:
+                self.engine.execute(table.insert(row))
 
         return table
 
@@ -276,10 +277,12 @@ class TinyDemoDataWarehouse(object):
             }
             values.append(record)
             if len(values) > 100:
-                self.engine.execute(insert.values(values))
+                for row in values:
+                    self.engine.execute(insert.values(row))
                 del values[:]
 
-        self.engine.execute(insert.values(values))
+        for row in values:
+            self.engine.execute(insert.values(row))
 
     def table(self, name):
         return sa.Table(name, self.md, autoload=True)
@@ -335,7 +338,8 @@ class TinyDemoDataWarehouse(object):
     def insert(self, table_name, values):
         """Insert list of `values` into table `table_name`"""
         insert = self.table(table_name).insert()
-        self.engine.execute(insert, values)
+        for row in values:
+            self.engine.execute(insert, row)
 
     def dimension(self, table):
         """Returns a dimension lookup object for `table`."""

--- a/tests/sql/test_expression.py
+++ b/tests/sql/test_expression.py
@@ -34,7 +34,7 @@ class SQLExpressionTestCase(SQLTestCase):
                 [4, 80, 3]]
 
         for row in data:
-            self.engine.execute(insert.values(data))
+            self.engine.execute(insert.values(row))
 
         self.bases = ["id", "price", "quantity"]
         self.columns = {attr:self.table.columns[attr]


### PR DESCRIPTION
added core requirements install for travis; added sqlite3 <3.7.11 compatibility

to sql tests by avoiding multirow inserts; added 2.7 compat to SQLTestCase.