### PR TITLE
Add default coalesce value to aggregated measures.

### DIFF
--- a/cubes/browser.py
+++ b/cubes/browser.py
@@ -169,11 +169,12 @@ class AggregationBrowser(object):
                                                         calculated_aggs,
                                                         drilldon,
                                                         split)
+        result.cells = result._cells
 
         # Do calculated measures on summary if no drilldown or split
         for calc in result.calculators:
             if result.summary:
-                calc(result)
+                calc(result.summary)
             # if result.cells:
             #     calc(list(result.cells))
 

--- a/cubes/browser.py
+++ b/cubes/browser.py
@@ -156,13 +156,10 @@ class AggregationBrowser(object):
 
         drilldon = Drilldown(drilldown, cell)
 
-        builtin_aggregates = [agg for agg in aggregates
-                              if agg.function and \
-                              self.is_builtin_function(agg.function)]
-
+        aggregates = [agg for agg in aggregates if not agg.custom_agg]
 
         result = self.provide_aggregate(cell,
-                                        aggregates=builtin_aggregates,
+                                        aggregates=aggregates,
                                         drilldown=drilldon,
                                         split=split,
                                         order=order,

--- a/cubes/browser.py
+++ b/cubes/browser.py
@@ -145,8 +145,12 @@ class AggregationBrowser(object):
 
         drilldon = Drilldown(drilldown, cell)
 
+        builtin_aggregates = [agg for agg in aggregates
+                              if agg.function and \
+                              self.is_builtin_function(agg.function)]
+
         result = self.provide_aggregate(cell,
-                                        aggregates=aggregates,
+                                        aggregates=builtin_aggregates,
                                         drilldown=drilldon,
                                         split=split,
                                         order=order,
@@ -163,13 +167,16 @@ class AggregationBrowser(object):
 
         result.calculators = calculators_for_aggregates(self.cube,
                                                         calculated_aggs,
-                                                        drilldown,
+                                                        drilldon,
                                                         split)
 
         # Do calculated measures on summary if no drilldown or split
-        if result.summary:
-            for calc in result.calculators:
-                calc(result.summary)
+        for calc in result.calculators:
+            if result.summary:
+                calc(result)
+            # if result.cells:
+            #     calc(list(result.cells))
+
 
         return result
 
@@ -250,7 +257,7 @@ class AggregationBrowser(object):
                                                                agg.name))
                 dependencies.append(aggregate)
 
-        aggregates += dependencies
+        # aggregates += dependencies
         return aggregates
 
     def prepare_order(self, order, is_aggregate=False):

--- a/cubes/customagg.py
+++ b/cubes/customagg.py
@@ -1,0 +1,78 @@
+from itertools import groupby
+
+def _median_on_distribution(l):
+    """ Returns median on distribution
+
+    >>> _median_on_distribution([(1, 5), (2, 10), (5, 1), (7, 3), (11, 2)])
+    2
+    >>> _median_on_distribution([(1, 5), (2, 10), (5, 8), (7, 3), (11, 6)])
+    5
+    >>> _median_on_distribution([(1, 5), (2, 10), (5, 8), (7, 7)])
+    3.5
+    >>> _median_on_distribution([(1, 5), (7, 3), (5, 8), (11, 6), (2, 10)])
+    5
+    """
+    l.sort(key=lambda e: e[0])
+    head = tail = 0
+    hi, ti = 0, len(l)-1
+    while True:
+        if hi > ti:
+            if head > tail:
+                return l[hi-1][0]
+            elif tail > head:
+                return l[ti+1][0]
+            else:
+                return float(l[hi][0] + l[ti][0])/2
+        if head > tail:
+            tail += l[ti][1]
+            ti -= 1
+        else:
+            head += l[hi][1]
+            hi += 1
+
+def _extract_tuples( list_of_dicts, tuple_of_attrs):
+    """
+
+    Args:
+        list_of_dicts:
+        tuple_of_attrs:
+
+    Returns: list of tuples, taken from dict by keys stored in tuple_of_dicts
+
+    >>> l = [{'a':1, 'b':2, 'c':3}, {'a':101, 'b': 102, 'c': 103}]
+    >>> _extract_tuples(l, ['a', 'c'])
+    [(1, 3), (101, 103)]
+    """
+    result = []
+    for d in list_of_dicts:
+        elem = []
+        for a in tuple_of_attrs:
+            elem.append(d[a])
+        result.append(tuple(elem))
+    return result
+
+def median(result, measure, target):
+    measures = measure.split(',')
+    drilldowns = [d.dimension.name for d in result.drilldown]
+    group_keys = [k for k in drilldowns if not k in measures]
+    def group_key(elem):
+        key = []
+        for k in group_keys:
+            key.append(elem[k])
+        return tuple(key)
+    value, count = measures
+
+    grouped_cells = groupby(
+        sorted(result.cells, key=group_key),
+        key=group_key)
+
+    result._cells = []
+    for g in grouped_cells:
+        cell = dict(zip(group_keys, g[0]))
+        cell[target] = _median_on_distribution(_extract_tuples(g[1], (value, count)))
+        result._cells.append(cell)
+
+
+
+
+

--- a/cubes/model.py
+++ b/cubes/model.py
@@ -421,11 +421,28 @@ class Cube(ModelObject):
         that the model is not valid).
         """
         name = str(name)
-        try:
-            return self._aggregates[name]
-        except KeyError:
-            raise NoSuchAttributeError("Cube '%s' has no measure aggregate "
-                                            "'%s'" % (self.name, name))
+        measures = name.split(',')
+        if len(measures) == 1:
+            try:
+                return self._aggregates[name]
+            except KeyError:
+                raise NoSuchAttributeError("Cube '%s' has no measure aggregate "
+                                                "'%s'" % (self.name, name))
+        elif len(measures) > 1:
+            res_agg = None
+            for agg_name, agg in self._aggregates.items():
+                if agg.measure == name:
+                    res_agg = agg
+                    # try:
+                    #     return agg
+                    # except KeyError:
+                    #     raise NoSuchAttributeError("Cube '%s' has no measure aggregate "
+                    #                                     "'%s'" % (self.name, name))
+            if res_agg:
+                return res_agg
+            else:
+                raise NoSuchAttributeError("Cube '%s' has no measure aggregate "
+                                                "'%s'" % (self.name, name))
 
     def get_aggregates(self, names=None):
         """Get a list of aggregates with `names`."""

--- a/cubes/model.py
+++ b/cubes/model.py
@@ -2416,7 +2416,8 @@ class MeasureAggregate(AttributeBase):
     def __init__(self, name, label=None, description=None, order=None,
                  info=None, format=None, missing_value=None, measure=None,
                  function=None, formula=None, expression=None,
-                 nonadditive=None, window_size=None, **kwargs):
+                 nonadditive=None, window_size=None, custom_agg=None,
+                 drilldowns_required=None, **kwargs):
         """Masure aggregate
 
         Attributes:
@@ -2442,6 +2443,8 @@ class MeasureAggregate(AttributeBase):
         self.measure = measure
         self.nonadditive = nonadditive
         self.window_size = window_size
+        self.custom_agg = custom_agg
+        self.drilldowns_required = drilldowns_required
 
     def __deepcopy__(self, memo):
         return MeasureAggregate(self.name,
@@ -2456,7 +2459,9 @@ class MeasureAggregate(AttributeBase):
                                 formula=self.formula,
                                 expression=self.expression,
                                 nonadditive=self.nonadditive,
-                                window_size=self.window_size)
+                                window_size=self.window_size,
+                                custom_agg=self.custom_agg,
+                                drilldowns_required=self.drilldowns_required)
 
     def __eq__(self, other):
         if not super(MeasureAggregate, self).__eq__(other):
@@ -2466,14 +2471,16 @@ class MeasureAggregate(AttributeBase):
             and self.measure == other.measure \
             and self.formula == other.formula \
             and self.nonadditive == other.nonadditive \
-            and self.window_size == other.window_size
+            and self.window_size == other.window_size \
+            and self.custom_agg == other.custom_agg \
+            and self.drilldowns_required == other.drilldowns_required
 
     def __hash__(self):
         return hash(self.ref)
 
     @property
     def is_base(self):
-        return not self.expression and not self.function
+        return not self.expression and not self.function and not self.custom_agg
 
     def to_dict(self, **options):
         d = super(MeasureAggregate, self).to_dict(**options)
@@ -2482,6 +2489,8 @@ class MeasureAggregate(AttributeBase):
         d["measure"] = self.measure
         d["nonadditive"] = self.nonadditive
         d["window_size"] = self.window_size
+        d["custom_agg"] = self.custom_agg
+        d["drilldowns_required"] = self.custom_agg
 
         return d
 

--- a/cubes/model.py
+++ b/cubes/model.py
@@ -2423,7 +2423,7 @@ class MeasureAggregate(AttributeBase):
                  info=None, format=None, missing_value=None, measure=None,
                  function=None, formula=None, expression=None,
                  nonadditive=None, window_size=None, custom_agg=None,
-                 drilldowns_required=None, **kwargs):
+                 drilldowns_required=None, expression_custom_function=None, **kwargs):
         """Masure aggregate
 
         Attributes:
@@ -2451,6 +2451,7 @@ class MeasureAggregate(AttributeBase):
         self.window_size = window_size
         self.custom_agg = custom_agg
         self.drilldowns_required = drilldowns_required
+        self.expression_custom_function = expression_custom_function
 
     def __deepcopy__(self, memo):
         return MeasureAggregate(self.name,
@@ -2467,19 +2468,21 @@ class MeasureAggregate(AttributeBase):
                                 nonadditive=self.nonadditive,
                                 window_size=self.window_size,
                                 custom_agg=self.custom_agg,
-                                drilldowns_required=self.drilldowns_required)
+                                drilldowns_required=self.drilldowns_required,
+                                expression_custom_function=self.expression_custom_function)
 
     def __eq__(self, other):
         if not super(MeasureAggregate, self).__eq__(other):
             return False
 
         return str(self.function) == str(other.function) \
-            and self.measure == other.measure \
-            and self.formula == other.formula \
-            and self.nonadditive == other.nonadditive \
-            and self.window_size == other.window_size \
-            and self.custom_agg == other.custom_agg \
-            and self.drilldowns_required == other.drilldowns_required
+               and self.measure == other.measure \
+               and self.formula == other.formula \
+               and self.nonadditive == other.nonadditive \
+               and self.window_size == other.window_size \
+               and self.custom_agg == other.custom_agg \
+               and self.drilldowns_required == other.drilldowns_required \
+               and self.expression_custom_function == other.expression_custom_function
 
     def __hash__(self):
         return hash(self.ref)
@@ -2497,6 +2500,7 @@ class MeasureAggregate(AttributeBase):
         d["window_size"] = self.window_size
         d["custom_agg"] = self.custom_agg
         d["drilldowns_required"] = self.custom_agg
+        d["expression_custom_function"] = self.expression_custom_function
 
         return d
 

--- a/cubes/model.py
+++ b/cubes/model.py
@@ -925,6 +925,7 @@ class Dimension(Conceptual):
             info = template.info
             cardinality = template.cardinality
             role = template.role
+            native_time = template.native_time
             category = template.category
             nonadditive = template.nonadditive
         else:
@@ -936,6 +937,7 @@ class Dimension(Conceptual):
             description = None
             cardinality = None
             role = None
+            native_time = None
             category = None
             info = {}
             nonadditive = None
@@ -951,6 +953,7 @@ class Dimension(Conceptual):
         description = metadata.get("description") or description
         info = metadata.get("info", info)
         role = metadata.get("role", role)
+        native_time = metadata.get("native_time", native_time)
         category = metadata.get("category", category)
         nonadditive = metadata.get("nonadditive", nonadditive)
 
@@ -1039,6 +1042,7 @@ class Dimension(Conceptual):
                          info=info,
                          cardinality=cardinality,
                          role=role,
+                         native_time=native_time,
                          category=category,
                          nonadditive=nonadditive
                         )
@@ -1046,7 +1050,7 @@ class Dimension(Conceptual):
     # TODO: new signature: __init__(self, name, *attributes, **kwargs):
     def __init__(self, name, levels=None, hierarchies=None,
                  default_hierarchy_name=None, label=None, description=None,
-                 info=None, role=None, cardinality=None, category=None,
+                 info=None, role=None, native_time=None, cardinality=None, category=None,
                  master=None, nonadditive=None, attributes=None, **desc):
 
         """Create a new dimension
@@ -1091,6 +1095,7 @@ class Dimension(Conceptual):
         super(Dimension, self).__init__(name, label, description, info)
 
         self.role = role
+        self.native_time = native_time
         self.cardinality = cardinality
         self.category = category
 
@@ -1397,6 +1402,7 @@ class Dimension(Conceptual):
         out["default_hierarchy_name"] = self.hierarchy().name
 
         out["role"] = self.role
+        out["native_time"] = self.native_time
         out["cardinality"] = self.cardinality
         out["category"] = self.category
 

--- a/cubes/server/blueprint.py
+++ b/cubes/server/blueprint.py
@@ -470,7 +470,8 @@ def cube_members(cube_name, dimension_name):
                                depth=depth,
                                hierarchy=hierarchy,
                                page=g.page,
-                               page_size=g.page_size)
+                               page_size=g.page_size,
+                               order=g.order)
 
     result = {
         "dimension": dimension.name,

--- a/cubes/server/blueprint.py
+++ b/cubes/server/blueprint.py
@@ -379,7 +379,7 @@ def aggregate(cube_name):
                              include_header=bool(header),
                              header=header)
 
-    headers = {"Content-Disposition": 'attachment; filename="aggregate.csv"'}
+    headers = {"Content-Disposition": 'attachment; filename="aggregate_%s.csv"' % cube_name}
     return Response(generator,
                     mimetype='text/csv',
                     headers=headers)

--- a/cubes/sql/browser.py
+++ b/cubes/sql/browser.py
@@ -391,6 +391,12 @@ class SQLBrowser(AggregationBrowser):
         """
 
         # TODO: implement reminder
+        for agg in aggregates:
+            if agg.dependencies:
+                try:
+                    aggregates += self.cube.get_aggregates(agg.dependencies)
+                except KeyError:
+                    pass
 
         result = AggregationResult(cell=cell, aggregates=aggregates,
                                    drilldown=drilldown,

--- a/cubes/sql/browser.py
+++ b/cubes/sql/browser.py
@@ -391,12 +391,6 @@ class SQLBrowser(AggregationBrowser):
         """
 
         # TODO: implement reminder
-        for agg in aggregates:
-            if agg.dependencies:
-                try:
-                    aggregates += self.cube.get_aggregates(agg.dependencies)
-                except KeyError:
-                    pass
 
         result = AggregationResult(cell=cell, aggregates=aggregates,
                                    drilldown=drilldown,

--- a/cubes/sql/expressions.py
+++ b/cubes/sql/expressions.py
@@ -120,6 +120,9 @@ class SQLExpressionContext(object):
     def add_column(self, name, column):
         self._columns[name] = column
 
+    def add_function(self, name):
+        SQL_ALL_FUNCTIONS.append(name)
+
 
 def compile_attributes(bases, dependants, parameters, coalesce=None,
                        label=None):
@@ -130,6 +133,9 @@ def compile_attributes(bases, dependants, parameters, coalesce=None,
     compiler = SQLExpressionCompiler()
 
     for attr in dependants:
+        if hasattr(attr, 'expression_custom_function') and attr.expression_custom_function:
+            context.add_function(attr.expression_custom_function)
+
         # TODO: remove this hasattr with something nicer
         if hasattr(attr, "function") and attr.function:
             # Assumption: only aggregates have function, no measures or other

--- a/cubes/sql/functions.py
+++ b/cubes/sql/functions.py
@@ -171,6 +171,8 @@ class stddev(ReturnTypeFromArgs):
 class variance(ReturnTypeFromArgs):
     pass
 
+class quantile(ReturnTypeFromArgs):
+    pass
 
 _functions = (
     SummaryCoalescingFunction("sum", sql.functions.sum),
@@ -181,7 +183,9 @@ _functions = (
     ValueCoalescingFunction("max", sql.functions.max),
     ValueCoalescingFunction("avg", avg),
     ValueCoalescingFunction("stddev", stddev),
-    ValueCoalescingFunction("variance", variance)
+    ValueCoalescingFunction("variance", variance),
+    ValueCoalescingFunction("median", quantile, 0.5)
+
 )
 
 _function_dict = {}

--- a/cubes/sql/functions.py
+++ b/cubes/sql/functions.py
@@ -13,14 +13,15 @@ try:
     from sqlalchemy.sql.functions import ReturnTypeFromArgs
 except ImportError:
     from ...common import MissingPackage
+
     sqlalchemy = sql = MissingPackage("sqlalchemy", "SQL aggregation browser")
     missing_error = MissingPackage("sqlalchemy", "SQL browser extensions")
+
 
     class ReturnTypeFromArgs(object):
         def __init__(*args, **kwargs):
             # Just fail by trying to call missing package
             missing_error()
-
 
 __all__ = (
     "get_aggregate_function",
@@ -103,21 +104,25 @@ class AggregateFunction(object):
     def __str__(self):
         return self.name
 
+
 class ValueCoalescingFunction(AggregateFunction):
     def coalesce_value(self, aggregate, value):
         """Coalesce the value before aggregation of `aggregate`. `value` is a
         SQLAlchemy expression.  Default implementation coalesces to zero 0."""
-        # TODO: use measure's missing value (we need to get the measure object
-        # somehow)
-        return sql.functions.coalesce(value, 0)
+        # Using default value - 0 or "coalesce" attribute from "info" dict
+
+        coalesce = aggregate.info.get('coalesce', 0)
+        return sql.functions.coalesce(value, coalesce)
 
 
 class SummaryCoalescingFunction(AggregateFunction):
     def coalesce_aggregate(self, aggregate, value):
         """Coalesce the aggregated value of `aggregate`. `value` is a
         SQLAlchemy expression.  Default implementation does nothing."""
-        # TODO: use aggregates's missing value
-        return sql.functions.coalesce(value, 0)
+        # Using default value - 0 or "coalesce" attribute from "info" dict
+
+        coalesce = aggregate.info.get('coalesce', 0)
+        return sql.functions.coalesce(value, coalesce)
 
 
 class GenerativeFunction(AggregateFunction):
@@ -201,4 +206,3 @@ def available_aggregate_functions():
     """Returns a list of available aggregate function names."""
     _create_function_dict()
     return _function_dict.keys()
-

--- a/cubes/sql/query.py
+++ b/cubes/sql/query.py
@@ -631,6 +631,7 @@ class StarSchema(object):
         # Nowe we have to resolve all dependencies.
 
         required = {}
+        relevant_orig = set(relevant)
         while relevant:
             table = relevant.pop()
             required[table.key] = table
@@ -653,7 +654,11 @@ class StarSchema(object):
         fact = self.table(fact_key, "fact master")
         masters = {fact_key: fact}
 
-        sorted_tables = [fact]
+        sorted_tables = []
+        # Very fast query for joined dimensions and very big fact tables
+        # dirty, dirty hack
+        if fact in relevant_orig:
+            sorted_tables.append(fact)
 
         while required:
             details = [table for table in required.values()

--- a/cubes/sql/query.py
+++ b/cubes/sql/query.py
@@ -32,7 +32,6 @@ from ..cells import PointCut, SetCut, RangeCut
 
 from .expressions import compile_attributes
 
-
 # Default label for all fact keys
 FACT_KEY_LABEL = '__fact_key__'
 
@@ -50,6 +49,7 @@ Note that either `extract` or `function` can be used, not both."""
 
 Column = namedtuple("Column", ["schema", "table", "column",
                                "extract", "function"])
+
 
 #
 # IMPORTANT: If you decide to extend the above Mapping functionality by adding
@@ -135,7 +135,6 @@ def to_join_key(obj):
     .. versionadded:: 1.1
     """
 
-
     if obj is None:
         return JoinKey(None, None, None)
 
@@ -173,18 +172,19 @@ def to_join_key(obj):
 
     return JoinKey(schema, table, column)
 
+
 """Table join specification. `master` and `detail` are TableColumnReference
 tuples. `method` denotes which table members should be considered in the join:
 *master* – all master members (left outer join), *detail* – all detail members
 (right outer join) and *match* – members must match (inner join)."""
 
 Join = namedtuple("Join",
-                  ["master", # Master table (fact in star schema)
-                   "detail", # Detail table (dimension in star schema)
+                  ["master",  # Master table (fact in star schema)
+                   "detail",  # Detail table (dimension in star schema)
                    "alias",  # Optional alias for the detail table
                    "method"  # Method how the table is joined
-                  ]
-                 )
+                   ]
+                  )
 
 
 def to_join(obj):
@@ -226,14 +226,14 @@ def to_join(obj):
 
 # Internal table reference
 _TableRef = namedtuple("_TableRef",
-                       ["schema", # Database schema
-                        "name",   # Table name
+                       ["schema",  # Database schema
+                        "name",  # Table name
                         "alias",  # Optional table alias instead of name
-                        "key",    # Table key (for caching or referencing)
+                        "key",  # Table key (for caching or referencing)
                         "table",  # SQLAlchemy Table object, reflected
-                        "join"    # join which joins this table as a detail
-                       ]
-                      )
+                        "join"  # join which joins this table as a detail
+                        ]
+                       )
 
 
 class SchemaError(InternalError):
@@ -421,7 +421,7 @@ class StarSchema(object):
                                key=(self.schema, self.fact_name),
                                table=self.fact_table,
                                join=None
-                              )
+                               )
 
         self._tables[fact_table.key] = fact_table
 
@@ -468,7 +468,7 @@ class StarSchema(object):
                             alias=alias,
                             key=key,
                             join=join
-                           )
+                            )
 
             self._tables[key] = ref
 
@@ -534,7 +534,6 @@ class StarSchema(object):
             raise NoSuchTableError(msg)
 
         return table
-
 
     def column(self, logical):
         """Return a column for `logical` reference. The returned column will
@@ -702,7 +701,7 @@ class StarSchema(object):
         # Dictionary of raw tables and their joined products
         # At the end this should contain only one item representing the whole
         # star.
-        star_tables = {table_ref.key:table_ref.table for table_ref in tables}
+        star_tables = {table_ref.key: table_ref.table for table_ref in tables}
 
         # Here the `star` contains mapping table key -> table, which will be
         # gradually replaced by JOINs
@@ -881,11 +880,10 @@ class QueryContext(object):
 
         # Collect all the columns
         #
-        bases = {attr:self.star_schema.column(attr) for attr in base_names}
+        bases = {attr: self.star_schema.column(attr) for attr in base_names}
         bases[FACT_KEY_LABEL] = self.star_schema.fact_key_column
 
-        self._columns = compile_attributes(bases, dependants, parameters,
-                                           star_schema.label)
+        self._columns = compile_attributes(bases, dependants, parameters, coalesce_measure, star_schema.label)
 
         self.label_attributes = {}
         if self.safe_labels:
@@ -1004,7 +1002,6 @@ class QueryContext(object):
         levels = self.level_keys(dim, hierarchy, path)
 
         for level_key, value in zip(levels, path):
-
             # Prepare condition: dimension.level_key = path_value
             column = self.column(level_key)
             conditions.append(column == value)
@@ -1110,4 +1107,3 @@ class QueryContext(object):
         label = label or SPLIT_DIMENSION_NAME
 
         return split_column.label(label)
-

--- a/cubes/sql/utils.py
+++ b/cubes/sql/utils.py
@@ -19,10 +19,12 @@ __all__ = [
     "paginate_query"
 ]
 
+
 class CreateTableAsSelect(Executable, ClauseElement):
     def __init__(self, table, select):
         self.table = table
         self.select = select
+
 
 @compiles(CreateTableAsSelect)
 def visit_create_table_as_select(element, compiler, **kw):
@@ -33,6 +35,8 @@ def visit_create_table_as_select(element, compiler, **kw):
         element.table,
         compiler.process(element.select)
     )
+
+
 @compiles(CreateTableAsSelect, "sqlite")
 def visit_create_table_as_select(element, compiler, **kw):
     preparer = compiler.dialect.preparer(compiler.dialect)
@@ -43,10 +47,12 @@ def visit_create_table_as_select(element, compiler, **kw):
         compiler.process(element.select)
     )
 
+
 class CreateOrReplaceView(Executable, ClauseElement):
     def __init__(self, view, select):
         self.view = view
         self.select = select
+
 
 @compiles(CreateOrReplaceView)
 def visit_create_or_replace_view(element, compiler, **kw):
@@ -58,6 +64,7 @@ def visit_create_or_replace_view(element, compiler, **kw):
         compiler.process(element.select)
     )
 
+
 @compiles(CreateOrReplaceView, "sqlite")
 def visit_create_or_replace_view(element, compiler, **kw):
     preparer = compiler.dialect.preparer(compiler.dialect)
@@ -67,6 +74,7 @@ def visit_create_or_replace_view(element, compiler, **kw):
         full_name,
         compiler.process(element.select)
     )
+
 
 @compiles(CreateOrReplaceView, "mysql")
 def visit_create_or_replace_view(element, compiler, **kw):
@@ -145,11 +153,14 @@ def order_query(statement, order, natural_order=None, labels=None):
 
     # Collect the corresponding attribute columns
     for attribute, direction in order:
-        attribute = str(attribute)
-        column = order_column(columns[attribute], direction)
+        try:
+            attribute = str(attribute)
+            column = order_column(columns[attribute], direction)
 
-        if attribute not in final_order:
-            final_order[attribute] = column
+            if attribute not in final_order:
+                final_order[attribute] = column
+        except KeyError:
+            continue
 
     # Collect natural order for selected columns that have no explicit
     # ordering
@@ -160,4 +171,3 @@ def order_query(statement, order, natural_order=None, labels=None):
     statement = statement.order_by(*final_order.values())
 
     return statement
-

--- a/cubes/statutils.py
+++ b/cubes/statutils.py
@@ -195,7 +195,7 @@ class WindowFunction(object):
         print '__call_4_', self.target_attribute
         print '__call_5_', self.function
 
-        record = record.summary
+        #record = record.summary
 
         key = get_key(record, self.window_key)
 
@@ -295,7 +295,7 @@ class CellsFunction(object):
         for r in self.function(self.getattrs(cells, self.source_attributes)):
             cells[i][self.target_attribute] = r
             i += 1
-        result.cells = cells
+        result._cells = cells
 
 
 


### PR DESCRIPTION
We need this to prevent "division by zero" error in SQL engine for some of our expressions.
Example:

```
"aggregates": [
        {
          "name": "win_sum",
          "label": "Win sum",
          "measure": "win_count",
          "function": "sum",
          "info": {
            "coalesce": 1
          }
        },
        ...
        {
          "name": "difficulty",
          "label": "Difficulty",
          "expression": "(fail_sum * 100.0) / (fail_sum + win_sum)"
        }
]
```
