### PR TITLE
Change formatters doc example from "text_table" option

### DIFF
--- a/doc/formatters.rst
+++ b/doc/formatters.rst
@@ -7,22 +7,18 @@ multiple forms using formatters:
 
 .. code-block:: python
 
-    formatter = cubes.create_formatter("text_table")
+    formatter = cubes.create_formatter("cross_table")
 
     result = browser.aggregate(cell, drilldown="date")
 
-    print formatter.format(result, "date")
+    print formatter.format(result, "date")  # This line doesn't work any more - what should it be?
 
 
 Available formatters:
 
-* `text_table` – text output for result of drilling down through one
-  dimension
-* `simple_data_table` – returns a dictionary with `header` and `rows`
-* `simple_html_table` – returns a HTML table representation of result table
-  cells
 * `cross_table` – cross table structure with attributes `rows` – row headings,
   `columns` – column headings and `data` with rows of cells
+* `csv` - comma-separated values
 * `html_cross_table` – HTML version of the `cross_table` formatter
 
 .. seealso::


### PR DESCRIPTION
This looks like a great framework, thanks! I am spending some time getting my head around how it works, and thought I'd start by submitting a PR for a documentation change :-)
 
I noticed the example at http://cubes.readthedocs.io/en/v1.1/formatters.html doesn't work, because it references the "text_table" formatter, which is no longer available by default.

This PR needs a tiny change to merge - the old line

    print formatter.format(result, "date") 

needs to be replaced, but I'm not sure what with yet.

Btw, I notice the slicer server accepts a `format=json|csv` parameter; I was looking at https://github.com/DataBrewery/cubes/blob/release-1.1/cubes/ext.py#L50-L52 because I guessed the allowed formats would match those (but they don't)...