### PR TITLE
parse the config file before passing to create server

### DIFF
--- a/cubes/server/app.py
+++ b/cubes/server/app.py
@@ -2,6 +2,7 @@
 
 import os
 from .base import create_server
+from .base import read_slicer_config
 from .utils import str_to_bool
 
 # Set the configuration file
@@ -10,7 +11,8 @@ try:
 except KeyError:
     CONFIG_PATH = os.path.join(os.getcwd(), "slicer.ini")
 
-application = create_server(CONFIG_PATH)
+config = read_slicer_config(CONFIG_PATH)
+application = create_server(config)
 
 debug = os.environ.get("SLICER_DEBUG")
 if debug and str_to_bool(debug):


### PR DESCRIPTION
at the moment running the server with uwsgi doesnt work as it passes the string path to the server instead of the config object, it fails with:

```
Traceback (most recent call last):
  File "/Documents/cubes/cubes/server/app.py", line 13, in <module>
    application = create_server(CONFIG_PATH)
  File "/Documents/cubes/cubes/server/base.py", line 38, in create_server
    if config.has_option("server", "modules"):
AttributeError: 'str' object has no attribute 'has_option'
```

this PR matches the behaviour of the slicer command `https://github.com/DataBrewery/cubes/blob/master/cubes/slicer/commands.py#L59`