### PR TITLE
Implemented BrowserFeatures (#406)

### DIFF
--- a/cubes/query/browser.py
+++ b/cubes/query/browser.py
@@ -16,6 +16,7 @@ from typing import (
         Tuple,
         Union,
         cast,
+        NamedTuple,
     )
 
 # FIXME: Update afetr Python 3.6.1
@@ -75,6 +76,12 @@ _OrderArgType = Union[str, Union[_OrderType, Tuple[str,str]]]
 _ReportResult = Union[AggregationResult, Facts, JSONType, List[JSONType]] 
 
 
+class BrowserFeatures(NamedTuple):
+    actions: Iterable[str]
+    aggregate_functions: Iterable[str]
+    post_aggregate_functions: Iterable[str]
+
+
 class AggregationBrowser:
     """Class for browsing data cube aggregations
 
@@ -113,7 +120,7 @@ class AggregationBrowser:
         self.calendar = None
 
     # TODO: Make this an explicit structure
-    def features(self) -> JSONType:
+    def features(self) -> BrowserFeatures:
         """Returns a dictionary of available features for the browsed cube.
         Default implementation returns an empty dictionary.
 
@@ -126,7 +133,7 @@ class AggregationBrowser:
 
         Subclasses are advised to override this method.
         """
-        return {}
+        return BrowserFeatures()
 
     # TODO: No *options
     def aggregate(self,

--- a/cubes/server/browser.py
+++ b/cubes/server/browser.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+
+from ..query.browser import BrowserFeatures
 from ..logging import get_logger
 from ..query import *
 
@@ -18,15 +20,15 @@ class SlicerBrowser(AggregationBrowser):
         self.locale = locale
         self.store = store
 
-    def features(self):
+    def features(self) -> BrowserFeatures:
 
         # Get the original features as provided by the Slicer server.
         # They are stored in browser_options in the Slicer model provider's
         # cube().
-        features = dict(self.cube.browser_options.get("features", {}))
+        features = BrowserFeatures(**dict(self.cube.browser_options.get("features", {})))
 
         # Replace only the actions, as we are not just a simple proxy.
-        features["actions"] = ["aggregate", "facts", "fact", "cell", "members"]
+        features.actions = ["aggregate", "facts", "fact", "cell", "members"]
 
         return features
 

--- a/cubes/sql/browser.py
+++ b/cubes/sql/browser.py
@@ -18,7 +18,7 @@ except ImportError:
     sqlalchemy = sql = MissingPackage("sqlalchemy", "SQL aggregation browser")
 
 from ..query import available_calculators
-from ..query.browser import AggregationBrowser
+from ..query.browser import AggregationBrowser, BrowserFeatures
 from ..query.result import AggregationResult
 from ..query.drilldown import Drilldown
 from ..query.cells import Cell, PointCut
@@ -201,11 +201,11 @@ class SQLBrowser(AggregationBrowser):
         cube, however in the future they might depend on the SQL engine or
         other factors."""
 
-        features = {
+        features = BrowserFeatures(**{
             "actions": ["aggregate", "fact", "members", "facts", "cell"],
             "aggregate_functions": available_aggregate_functions(),
             "post_aggregate_functions": available_calculators()
-        }
+        })
 
         return features
 


### PR DESCRIPTION
Make the `Cube.features()` return a structure with well known and well typed properties instead of vague `JSONType`.

I kept `post_aggregate_functions` as it was returned by `SQLBrowser.features()`. We may as well rename it to the proposed `post_processed_aggregates` in #406.