### PR TITLE
Fixes incorrect handling of table alias in flat dimensions.

### DIFF
--- a/cubes/metadata/attributes.py
+++ b/cubes/metadata/attributes.py
@@ -249,10 +249,7 @@ class Attribute(AttributeBase):
     @dimension.setter
     def dimension(self, dimension):
         if dimension:
-            if dimension.is_flat and not dimension.has_details:
-                self.ref = dimension.name
-            else:
-                self.ref = dimension.name + '.' + str(self.name)
+            self.ref = dimension.name + '.' + str(self.name)
         else:
             self.ref = str(self.name)
         self._dimension = dimension


### PR DESCRIPTION
Fixes the issue causing the SQL browser to access an attribute using table name instead of the alias defined in the `joins` section.
