### PR TITLE
Fix import regression which prevent from unsing the command `slicer model validate`.

### DIFF
--- a/cubes/metadata/__init__.py
+++ b/cubes/metadata/__init__.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import
 
 from .base import *
 from .attributes import *
+from .defaults import *
 from .dimension import *
 from .cube import *
 from .providers import *
 from .localization import *
-

--- a/cubes/slicer/commands.py
+++ b/cubes/slicer/commands.py
@@ -20,7 +20,7 @@ from .. import compat
 from ..datastructures import AttributeDict
 from ..errors import InconsistencyError, ArgumentError, InternalError, UserError
 from ..formatters import csv_generator, SlicerJSONEncoder, JSONLinesGenerator, xlsx_generator
-from ..metadata import read_model_metadata, write_model_metadata_bundle
+from ..metadata import read_model_metadata, write_model_metadata_bundle, validate_model
 from ..workspace import Workspace
 from ..errors import CubesError
 from ..server import run_server
@@ -159,10 +159,10 @@ def validate(show_defaults, show_warnings, model_path):
     """Validate model metadata"""
 
     click.echo("Reading model %s" % model_path)
-    model = cubes.read_model_metadata(model_path)
+    model = read_model_metadata(model_path)
 
     click.echo("Validating model...")
-    result = cubes.providers.validate_model(model)
+    result = validate_model(model)
 
     error_count = 0
     warning_count = 0


### PR DESCRIPTION
A regression in the function linkage prevent the user from using the command `slicer model validate`.
See #457. The following commit reestablish the links fo the moved packages.

`cubes.metadata.*` is added to `cubes.metadata` because the validate_model
was previously a function part of it (ascendance compatibility).

Then, it impacts necessarily the new import added to
`cubes.slicer.commands`.

In the module `cubes.slicer.commands`, the packages `cubes` and
`cubes.providers` are no longer available, the link to the owned
functions are so rebuild.