### PR TITLE
Fix test tests.test_model.HierarchyTestCase.test_copy on py3k

### DIFF
--- a/cubes/metadata/dimension.py
+++ b/cubes/metadata/dimension.py
@@ -784,7 +784,7 @@ class Hierarchy(Conceptual):
                          label=self.label,
                          description=self.description,
                          info=copy.deepcopy(self.info, memo),
-                         levels=copy.deepcopy(self._levels.values(), memo))
+                         levels=copy.deepcopy(self._levels, memo).values())
 
     @property
     def levels(self):


### PR DESCRIPTION
The values returned by `OrderedDict.values()` is an instance of a class
that cannot be copied in py3k (a list in python 2). For this reason, the
following message appears :

> TypeError: can't pickle odict_values objects

The solution is to first copy the `OrderedDict` and then get the
iterator on his values.