### PR TITLE
Fix test_explicit in test_aggregates

### DIFF
--- a/tests/models/aggregates.json
+++ b/tests/models/aggregates.json
@@ -19,6 +19,11 @@
             ],
             "aggregates": [
                 {
+                    "name": "amount_sum",
+                    "measure": "amount",
+                    "function": "sum"
+                },
+                {
                     "name": "count",
                     "function": "count"
                 }    


### PR DESCRIPTION
[test_explicit](https://github.com/DataBrewery/cubes/blob/140133e8c2e3f2ff60631cc3ebc9966d16c1655e/tests/sql/test_aggregates.py#L60) was failing because `amount_sum` aggregate was missing from `defaut `cube.

