### PR TITLE
to avoid 0 padding in Py3.5+ do not truncate

### DIFF
--- a/cubes/formatters.py
+++ b/cubes/formatters.py
@@ -95,7 +95,6 @@ def csv_generator_p3(records, fields, include_header=True, header=None,
     def _row_string(row):
         writer.writerow(row)
         data = queue.getvalue()
-        queue.truncate(0)
 
         return data
 


### PR DESCRIPTION
I noticed this when testing out Cubes - specifically the the Slicer server.

I was running in Python 3.8.1 and noticed that CSVs had many null bytes - lots of them. This was causing all types of problems when loading and parsing these CSV. Upon tracking down the issue I noticed this was the result of calling `truncate on a StringIO stream.

Specifically [the docs state](https://docs.python.org/3/library/io.html#io.IOBase.truncate):

"_Changed in version 3.5:_ Windows will now zero-fill files when extending."


