### PR TITLE
docs: fix simple typo, sohuld -> should

### DIFF
--- a/cubes/sql/query.py
+++ b/cubes/sql/query.py
@@ -431,7 +431,7 @@ class StarSchema(object):
         # provided explicitly for the snowflake schema.
 
 
-        # Collect details for duplicate verification. It sohuld not be
+        # Collect details for duplicate verification. It should not be
         # possible to join one detail multiple times with the same name. Alias
         # has to be used.
         details = set()


### PR DESCRIPTION
There is a small typo in cubes/sql/query.py.

Should read `should` rather than `sohuld`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md